### PR TITLE
Disable remove button on empty list

### DIFF
--- a/NetTuner/Views/SettingsView.swift
+++ b/NetTuner/Views/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingsView: View {
             ToolbarItem() {
                 Button("Remove", systemImage: "minus", action: {
                     deleteSelection()
-                })
+                }).disabled(radios.isEmpty)
             }
         }
     }


### PR DESCRIPTION
Disable the remove button from the settings view when the resulting radio model query is empty

```
Fatal error: Context didn't throw upon error condition
```