### PR TITLE
UI revamp

### DIFF
--- a/NetTuner/NetTunerApp.swift
+++ b/NetTuner/NetTunerApp.swift
@@ -11,11 +11,22 @@ import CoreData
 @main
 struct NetTunerApp: App {
     
+    @State var audioController: AudioController = AudioController()
+    
     var body: some Scene {
         
-        MenuBarExtra("NetTuner", systemImage: "radio") {
+        MenuBarExtra {
             MenuBarView()
                 .modelContainer(for: RadioStation.self)
+                .environment(audioController)
+        } label: {
+            HStack {
+                if audioController.status == .playing {
+                    Image(systemName: "radio.fill")
+                } else {
+                    Image(systemName: "radio")
+                }
+            }
         }
         .menuBarExtraStyle(.window)
         .defaultSize(width: 300, height: 350)

--- a/NetTuner/Views/MenuBarView.swift
+++ b/NetTuner/Views/MenuBarView.swift
@@ -67,7 +67,9 @@ struct MenuBarView: View {
                             if radio == selectedRadio {
                                 switch audioController.status {
                                 case .playing:
-                                    Image(systemName: "speaker.wave.3.fill")
+                                    Image(systemName: "play.fill")
+                                case .paused:
+                                    Image(systemName: "pause.fill")
                                 case .loading:
                                     Image(systemName: "network").symbolEffect(.pulse)
                                 case .failed:
@@ -91,6 +93,21 @@ struct MenuBarView: View {
             // Playback controls
             VStack {
                 HStack {
+                    
+                    switch audioController.status {
+                    case .playing, .paused:
+                        Button(action: {
+                            selectedRadio = nil
+                            audioController.stop()
+                        }) {
+                            Image(systemName: "stop.circle")
+                                .font(.title)
+                        }.buttonStyle(PlainButtonStyle())
+                    default:
+                        EmptyView()
+                    }
+
+
                     switch audioController.status {
                     case .paused:
                         Button(action: {
@@ -122,7 +139,7 @@ struct MenuBarView: View {
                         Image(systemName: "music.note").font(.largeTitle)
                     }
 
-                    Text(audioController.statusString).font(.largeTitle)
+                    Text(audioController.statusString).font(.title)
 
                     Spacer()
                 }.padding()
@@ -143,6 +160,7 @@ struct MenuBarView: View {
             }.padding()
 
         }.background()
+
     }
 }
 

--- a/NetTuner/Views/MenuBarView.swift
+++ b/NetTuner/Views/MenuBarView.swift
@@ -11,7 +11,7 @@ import SwiftData
 struct MenuBarView: View {
     @Environment(\.openWindow) var openWindow
 
-    @State var audioController: AudioController = AudioController()
+    @Environment(AudioController.self) private var audioController
     @State private var volume: Float = 1.0
 
     @Environment(\.modelContext) var modelContext
@@ -25,6 +25,8 @@ struct MenuBarView: View {
 
     var body: some View {
         VStack {
+            
+            // Header
             HStack {
                 Text("NetTuner").font(.largeTitle)
                 Label("", systemImage: "wave.3.forward")
@@ -35,13 +37,14 @@ struct MenuBarView: View {
                 Spacer()
                 Menu {
                     Button(action: {
+                        NSApplication.shared.activate(ignoringOtherApps: true)
                         openWindow(id: "settings")
                     }) {
                         Text("Radio Stations")
                     }.keyboardShortcut(",", modifiers: .command)
                     
                     Button(action: {
-                        exit(0)
+                        NSApplication.shared.terminate(nil)
                     }) {
                         Text("Quit")
                     }.keyboardShortcut("q", modifiers: .command)
@@ -54,6 +57,7 @@ struct MenuBarView: View {
             }.frame(maxWidth: .infinity, alignment: .center)
              .padding()
 
+            // Radio List
             if !sortedRadios.isEmpty {
                 List(selection: $selectedRadio) {
                     ForEach(sortedRadios, id: \.self) { radio in
@@ -84,6 +88,7 @@ struct MenuBarView: View {
                     .padding(.horizontal)
             }
             
+            // Playback controls
             VStack {
                 HStack {
                     switch audioController.status {


### PR DESCRIPTION
Major UI revamp and fixes:
- Handling of Observable AudioController being shared across the application, allowing the menubar icon to change on playing.
- Focus on settings window being opened
- Stop button added on playback
- Application exit handled by `NSApplication.shared.terminate(nil)`

<img width="346" alt="Screenshot 2024-05-07 at 09 28 49" src="https://github.com/garamb1/NetTuner/assets/3776646/2c2295dd-131b-4c39-a7cc-8256ff2b62e6">
